### PR TITLE
fix: añadido selenium a requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ django-nose==1.4.6
 jsonnet==0.12.1
 django-heroku
 gunicorn
+selenium


### PR DESCRIPTION
Con esto logramos que cuando travis ejecute "pip install -r requirements.txt" también instale selenium y pueda ejecutar las pruebas relacionadas. Issue #79